### PR TITLE
UCSBOrganization controller PUT endpoint + tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -1,16 +1,19 @@
 package edu.ucsb.cs156.example.controllers;
 
+import javax.validation.Valid;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import edu.ucsb.cs156.example.entities.UCSBOrganization;
 import edu.ucsb.cs156.example.errors.EntityNotFoundException;
-import edu.ucsb.cs156.example.repositories.UCSBDiningCommonsRepository;
 import edu.ucsb.cs156.example.repositories.UCSBOrganizationRepository;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -44,7 +47,7 @@ public class UCSBOrganizationController extends ApiController{
 
         return organization;
     }
-    
+
     @ApiOperation(value = "Create a new organization")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")
@@ -67,4 +70,26 @@ public class UCSBOrganizationController extends ApiController{
 
         return savedOrganization;
     }
+
+    @ApiOperation(value = "Update a single commons")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBOrganization updateCommons(
+            @ApiParam("code") @RequestParam String orgCode,
+            @RequestBody @Valid UCSBOrganization incoming) {
+
+        UCSBOrganization org = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+        
+        org.setOrgCode(incoming.getOrgCode());
+        org.setOrgTranslationShort(incoming.getOrgTranslationShort());
+        org.setOrgTranslation(incoming.getOrgTranslation());
+        org.setInactive(incoming.getInactive());
+
+
+        ucsbOrganizationRepository.save(org);
+
+        return org;
+    }
+    
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -34,6 +34,17 @@ public class UCSBOrganizationController extends ApiController{
         return organizations;
     }
 
+    @ApiOperation(value = "Get a single organization")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public UCSBOrganization getById(
+            @ApiParam("orgCode") @RequestParam String orgCode) {
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+        return organization;
+    }
+    
     @ApiOperation(value = "Create a new organization")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping("/post")

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationControllerTests.java
@@ -56,6 +56,12 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                             .andExpect(status().is(200)); // logged
     }
 
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+            mockMvc.perform(get("/api/UCSBOrganization?orgCode=cdp"))
+                            .andExpect(status().is(403)); // logged out users can't get by id
+    }
+    
     // Authorization tests for /api/UCSBOrganization/post
     // (Perhaps should also have these for put and delete)
 
@@ -110,6 +116,54 @@ public class UCSBOrganizationControllerTests extends ControllerTestCase {
                 String expectedJson = mapper.writeValueAsString(expectedOrganizations);
                 String responseString = response.getResponse().getContentAsString();
                 assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+
+                // arrange
+
+                UCSBOrganization org = UCSBOrganization.builder()
+                                .orgCode("VSA")
+                                .orgTranslationShort("VIETNAMESE STUDENT")
+                                .orgTranslation("VIETNAMESE STUDENT ASSOCIATION")
+                                .inactive(false)
+                                .build();
+
+
+                when(ucsbOrganizationRepository.findById(eq("VSA"))).thenReturn(Optional.of(org));
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization?orgCode=VSA"))
+                                .andExpect(status().isOk()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("VSA"));
+                String expectedJson = mapper.writeValueAsString(org);
+                String responseString = response.getResponse().getContentAsString();
+                assertEquals(expectedJson, responseString);
+        }
+
+        @WithMockUser(roles = { "USER" })
+        @Test
+        public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+                // arrange
+
+                when(ucsbOrganizationRepository.findById(eq("VSA"))).thenReturn(Optional.empty());
+
+                // act
+                MvcResult response = mockMvc.perform(get("/api/UCSBOrganization?orgCode=VSA"))
+                                .andExpect(status().isNotFound()).andReturn();
+
+                // assert
+
+                verify(ucsbOrganizationRepository, times(1)).findById(eq("VSA"));
+                Map<String, Object> json = responseToJson(response);
+                assertEquals("EntityNotFoundException", json.get("type"));
+                assertEquals("UCSBOrganization with id VSA not found", json.get("message"));
         }
 
         @WithMockUser(roles = { "ADMIN", "USER" })


### PR DESCRIPTION
This PR implements the PUT endpoint of the UCSBOrganization controller so that a single record can be edited. The methods are all tested

This closes issue #22 